### PR TITLE
feat(gallery): improvements

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -112,7 +112,7 @@
       "format": "esm"
     },
     "src/js/components/gallery.js": {
-      "bytes": 9501,
+      "bytes": 9563,
       "imports": [
         {
           "path": "src/js/components/state.js",
@@ -332,7 +332,7 @@
           "bytesInOutput": 363
         },
         "src/js/components/gallery.js": {
-          "bytesInOutput": 5127
+          "bytesInOutput": 5161
         },
         "src/js/components/file-tree.js": {
           "bytesInOutput": 2050
@@ -350,7 +350,7 @@
           "bytesInOutput": 376
         }
       },
-      "bytes": 25947
+      "bytes": 25981
     },
     "public/js/bundle.css": {
       "imports": [

--- a/src/js/components/gallery.js
+++ b/src/js/components/gallery.js
@@ -90,6 +90,8 @@ function createWallpaperItem(wallpaper) {
 
 	img.alt = `Wallpaper: ${wallpaper.name}`;
 	img.loading = 'lazy'; // Native lazy loading as a fallback
+	img.width = wallpaper.width;
+	img.height = wallpaper.height;
 
 	// Set sizes attribute to give the browser hints on how the image will be displayed
 	img.sizes = '(max-width: 600px) 45vw, (max-width: 1200px) 30vw, 20vw';


### PR DESCRIPTION
Adds the `width` and `height` attributes to the `img` tag for wallpaper images in the gallery. This improves browser rendering and lazy loading.